### PR TITLE
Fix: gibberish subs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ktuvit-stremio",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ktuvit-stremio",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "config": "^3.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "fastest-levenshtein": "^1.0.16",
-        "ktuvit-api": "^0.3.0",
+        "ktuvit-api": "^0.4.0",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -417,6 +417,11 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chardet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.1.tgz",
+      "integrity": "sha512-0XMOtA52igKDOIfvJZJ6v0+J9yMF3IuYyEa5oFUxBXA01G6mwCNKpul3bgbFf7lmZuqwN/oyg/zQ1cGS7NyJkQ=="
     },
     "node_modules/color": {
       "version": "3.2.1",
@@ -1594,14 +1599,26 @@
       }
     },
     "node_modules/ktuvit-api": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ktuvit-api/-/ktuvit-api-0.3.0.tgz",
-      "integrity": "sha512-xrf67GPgp01z4KFmFXjwHbe6TWQBv5EjYG/IszcsBXcA4sfLhbYCcOHqjFiQe//MxrPXZw2MncJvzh/XXSOoqg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ktuvit-api/-/ktuvit-api-0.4.0.tgz",
+      "integrity": "sha512-AcS0m22s4SAJBIqgST7Wrr5RwvQpErpFEHuWMo4tSHJl3frbkw0FX4MmC+IyrOG6dokY1QPfsZBqomK4fH9iQg==",
       "dependencies": {
+        "chardet": "^1.5.1",
+        "iconv-lite": "^0.6.3",
         "jsdom": "^16.4.0",
         "name-to-imdb": "^3.0.1",
-        "superagent": "^6.1.0",
-        "superagent-charset": "^1.2.0"
+        "superagent": "^6.1.0"
+      }
+    },
+    "node_modules/ktuvit-api/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/kuler": {
@@ -2422,14 +2439,6 @@
       },
       "engines": {
         "node": ">= 7.0.0"
-      }
-    },
-    "node_modules/superagent-charset": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/superagent-charset/-/superagent-charset-1.2.0.tgz",
-      "integrity": "sha512-1qgAqpQmUlequetXb/Rg3ExEDoIf6hdVHm6H6skABL8nVGErPzcLEJ7Keke568P9ymvUxVyBpq3svBgKExo3gg==",
-      "dependencies": {
-        "iconv-lite": "^0.4.16"
       }
     },
     "node_modules/superagent/node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ktuvit-stremio",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An unofficial Stremio addon for ktuvit.me",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "fastest-levenshtein": "^1.0.16",
-    "ktuvit-api": "^0.3.0",
+    "ktuvit-api": "^0.4.0",
     "winston": "^3.8.2"
   }
 }


### PR DESCRIPTION
Updated Ktuvit-api to 0.4.0.
The new version autodetects encoding which fixes subs that were wrongfully encoded as ISO-8859-8 mentioned in #37 .