### PR TITLE
fix: Fix retuning before exporting logger

### DIFF
--- a/common/logger.js
+++ b/common/logger.js
@@ -1,5 +1,4 @@
 const { createLogger, format, transports } = require("winston");
-const config = require("config");
 
 const customFormat = format.printf(({ level, message, timestamp }) => {
   return `${timestamp} [${level}]: ${message}`;
@@ -21,13 +20,12 @@ const logger = createLogger({
   ],
 });
 
-if (config.util.getEnv("NODE_ENV") !== "development")
-  // Suspicious of this causing a "max file size exceeded" error
-  // so I'm disabling local logs on prod until remote logging feature is implemented
+// Suspicious of this causing a "max file size exceeded" error
+// so I'm disabling local logs on prod until remote logging feature is implemented
 
-  // logger.add(
-  //   new transports.File({ filename: "ktuvit.log", format: format.json() })
-  // );
-  return;
+// if (config.util.getEnv("NODE_ENV") !== "development")
+// logger.add(
+//   new transports.File({ filename: "ktuvit.log", format: format.json() })
+// );
 
 module.exports = logger;


### PR DESCRIPTION
Accidentally left a return statement before exporting the logger causing the addon deployment to fail.