### PR TITLE
CI:  Added empty commit to deployment

### DIFF
--- a/.github/workflows/beamup-deployment.yml
+++ b/.github/workflows/beamup-deployment.yml
@@ -38,4 +38,8 @@ jobs:
           ssh dokku@a.baby-beamup.club config:set 4b139a4b7f94/ktuvit-stremio KTUVIT_USER_EMAIL="$KTUVIT_USER_EMAIL"
           ssh dokku@a.baby-beamup.club config:set 4b139a4b7f94/ktuvit-stremio KTUVIT_USER_HASHED_PASSWORD="$KTUVIT_USER_HASHED_PASSWORD"
       - name: Deploy addon to beamup
-        run: git push beamup HEAD:master --force
+        run: |
+          git config user.name "github-cd"
+          git config user.email "cd@github.com"
+          git commit --allow-empty -m "Beamup empty auto commit"
+          git push beamup HEAD:master --force


### PR DESCRIPTION
When manually deploying the addon with no changes, Beamup doesn't really restart the container because there are no new commits so this is done to avoid that.

The empty commit is reverted and created on each deployment so it doesn't have any impact.