### PR TITLE
fix: reject invalid SRT content from Ktuvit instead of caching it as valid

### DIFF
--- a/routes/downloadSrt.js
+++ b/routes/downloadSrt.js
@@ -4,6 +4,11 @@ const logger = require("../common/logger");
 
 const DETECTION_BYTES = config.get("bytesNeededForDetection");
 
+// Ktuvit sometimes returns an error message (e.g. an expired download
+// identifier) with a 200 status instead of actual subtitle content. Requiring
+// a timestamp line catches that case regardless of the exact wording.
+const SRT_TIMESTAMP_PATTERN = /\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/;
+
 let ktuvit;
 const initSrtDownloader = async () => {
   ktuvit = await initKtuvitManager();
@@ -11,27 +16,36 @@ const initSrtDownloader = async () => {
 };
 
 const downloadSrtFromKtuvit = (req, res) => {
-  res.setHeader("Content-Type", "application/x-subrip; charset=utf-8");
-
   const titleKtuvitId = req.params?.ktuvitId;
   const subKtuvitId = req.params?.subId;
 
-  const pipeFile = (fileBuffer) => {
-    res.end(Buffer.from(fileBuffer));
+  const respondWithError = (err, description) => {
+    logger.error(err || new Error(description), {
+      ktuvitTitleID: titleKtuvitId,
+      ktuvitSubID: subKtuvitId,
+      description,
+    });
+    // Never let a failed fetch be cached (by Cloudflare or anyone else) as if
+    // it were a valid subtitle file.
+    res.setHeader("Cache-Control", "no-store");
+    res.status(502).send("Could not fetch SRT file.");
+  };
+
+  const pipeFile = (fileContent, err) => {
+    if (err || !SRT_TIMESTAMP_PATTERN.test(fileContent || "")) {
+      respondWithError(err, "Ktuvit did not return a valid SRT file.");
+      return;
+    }
+
+    res.setHeader("Content-Type", "application/x-subrip; charset=utf-8");
+    res.end(Buffer.from(fileContent));
   };
 
   ktuvit
     .downloadSubtitle(titleKtuvitId, subKtuvitId, pipeFile, {
       bytesAmountForDetection: DETECTION_BYTES,
     })
-    .catch((err) => {
-      logger.error(err, {
-        ktuvitTitleID: titleKtuvitId,
-        ktuvitSubID: subKtuvitId,
-        description: "Error downloading SRT file.",
-      });
-      res.status(500).send("Could not fetch SRT file.");
-    });
+    .catch((err) => respondWithError(err, "Error downloading SRT file."));
 };
 
 module.exports = { initSrtDownloader, downloadSrtFromKtuvit };

--- a/test/unit/routes/downloadSrt.spec.js
+++ b/test/unit/routes/downloadSrt.spec.js
@@ -2,7 +2,11 @@ const assert = require("assert");
 const sinon = require("sinon");
 const proxyquire = require("proxyquire").noCallThru();
 
+const srtWithText = (text) =>
+  `1\n00:00:01,000 --> 00:00:04,000\n${text}\n`;
+
 const HEBREW_TEXT = "שלום עולם\nThis is a Hebrew subtitle line.";
+const KTUVIT_ERROR_MESSAGE = "הבקשה לא נמצאה, נא לנסות להוריד את הקובץ בשנית";
 
 describe("downloadSrtFromKtuvit", function () {
   let downloadSrtFromKtuvit;
@@ -36,7 +40,7 @@ describe("downloadSrtFromKtuvit", function () {
 
   it("should serve subtitle content as a UTF-8 buffer", function () {
     mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
-      cb(HEBREW_TEXT);
+      cb(srtWithText(HEBREW_TEXT));
       return Promise.resolve();
     });
 
@@ -47,7 +51,7 @@ describe("downloadSrtFromKtuvit", function () {
     assert.ok(Buffer.isBuffer(buffer), "Response should be a Buffer");
     assert.strictEqual(
       buffer.toString("utf8"),
-      HEBREW_TEXT,
+      srtWithText(HEBREW_TEXT),
       "Buffer should decode to the original string as UTF-8"
     );
   });
@@ -55,7 +59,7 @@ describe("downloadSrtFromKtuvit", function () {
   it("should serve ISO-8859-8 decoded content as UTF-8", function () {
     const iso88598Decoded = "שבת שלום";
     mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
-      cb(iso88598Decoded);
+      cb(srtWithText(iso88598Decoded));
       return Promise.resolve();
     });
 
@@ -63,12 +67,12 @@ describe("downloadSrtFromKtuvit", function () {
     downloadSrtFromKtuvit(req, res);
 
     const [buffer] = res.end.firstCall.args;
-    assert.strictEqual(buffer.toString("utf8"), iso88598Decoded);
+    assert.strictEqual(buffer.toString("utf8"), srtWithText(iso88598Decoded));
   });
 
   it("should set content-type header with utf-8 charset", function () {
     mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
-      cb("");
+      cb(srtWithText(""));
       return Promise.resolve();
     });
 
@@ -78,5 +82,53 @@ describe("downloadSrtFromKtuvit", function () {
     assert.ok(
       res.setHeader.calledWith("Content-Type", "application/x-subrip; charset=utf-8")
     );
+  });
+
+  it("should reject a non-SRT response with a non-cacheable error instead of serving it as a subtitle", function () {
+    mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
+      // Ktuvit returns this when the download identifier is stale/invalid,
+      // with an HTTP 200 status, so we can't rely on the transport layer to
+      // catch it for us.
+      cb(KTUVIT_ERROR_MESSAGE);
+      return Promise.resolve();
+    });
+
+    const req = { params: { ktuvitId: "TITLE123", subId: "SUB456" } };
+    downloadSrtFromKtuvit(req, res);
+
+    assert.ok(res.setHeader.calledWith("Cache-Control", "no-store"));
+    assert.ok(res.status.calledWith(502));
+    assert.ok(res.send.called);
+    assert.ok(res.end.notCalled, "Invalid content should never be sent as the response body");
+  });
+
+  it("should reject with a non-cacheable error when the download callback reports an error", function () {
+    mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
+      cb(null, new Error("network failure"));
+      return Promise.resolve();
+    });
+
+    const req = { params: { ktuvitId: "TITLE123", subId: "SUB456" } };
+    downloadSrtFromKtuvit(req, res);
+
+    assert.ok(res.setHeader.calledWith("Cache-Control", "no-store"));
+    assert.ok(res.status.calledWith(502));
+    assert.ok(res.end.notCalled);
+  });
+
+  it("should reject with a non-cacheable error when the initial request rejects", async function () {
+    mockKtuvit.downloadSubtitle.callsFake(() => {
+      return Promise.reject(new Error("could not obtain download identifier"));
+    });
+
+    const req = { params: { ktuvitId: "TITLE123", subId: "SUB456" } };
+    downloadSrtFromKtuvit(req, res);
+
+    // Let the rejected promise's .catch() handler run.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.ok(res.setHeader.calledWith("Cache-Control", "no-store"));
+    assert.ok(res.status.calledWith(502));
+    assert.ok(res.end.notCalled);
   });
 });


### PR DESCRIPTION
## Summary
- Ktuvit occasionally returns an error message (e.g. an expired download identifier) with an HTTP 200 status instead of actual subtitle content. That was being served straight through as a valid `.srt` file and cached by Cloudflare for hours, breaking playback for every subsequent viewer requesting that specific file.
- Confirmed live via Android TV logcat: libVLC explicitly logged `failed to add ... as slave` when handed one of these cached error responses.
- `downloadSrtFromKtuvit` now validates the response contains a real SRT timestamp line before serving it; any failure path (invalid content, download callback error, or a rejected identifier request) now returns `502` with `Cache-Control: no-store` so it can never get cached as if it were valid.
- Also fixes a related latent bug where the download callback's error path (`cb(null, err)`) was silently mishandled and would have thrown on `Buffer.from(null)`.

## Test plan
- [x] `npm test` — all `downloadSrt` unit tests pass, including 3 new cases covering invalid content, callback error, and rejected identifier request
- [x] Reproduced the original bug directly against production (a subtitle whose Ktuvit download identifier expired, cached by Cloudflare, confirmed failing in real device logs) and confirmed this is the exact failure path being fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)