### PR TITLE
chore: bump ktuvit-api to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.21.2",
         "fastest-levenshtein": "^1.0.16",
-        "ktuvit-api": "^0.4.2",
+        "ktuvit-api": "^0.4.3",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -2177,9 +2177,9 @@
       }
     },
     "node_modules/ktuvit-api": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ktuvit-api/-/ktuvit-api-0.4.2.tgz",
-      "integrity": "sha512-98p73Rx2calDc/LKdB/5P2fKJu1S6xXsh/mVroZrADIyC1huoJBOE0z/uSSRxNi0Z0j0/xCPkrywrUkezU1I+A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ktuvit-api/-/ktuvit-api-0.4.3.tgz",
+      "integrity": "sha512-GyEvrDbwsCcd/4y5pWdRU7RkNNhK7fjS+RFtNHWT+adIiZzPF2rjDjP/K7UQGwUFAB23VCBMO+AKNwl777Uv9g==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.21.2",
     "fastest-levenshtein": "^1.0.16",
-    "ktuvit-api": "^0.4.2",
+    "ktuvit-api": "^0.4.3",
     "winston": "^3.8.2"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `ktuvit-api` `0.4.2` → `0.4.3` to pick up [maormagori/Ktuvit-api#14](https://github.com/maormagori/Ktuvit-api/pull/14).
- That fix stops `extractSubsFromHtml` from crashing on Ktuvit's "no subtitles" placeholder row. In production logs this single crash accounted for ~95% of all logged errors (53k+ over 5 days) — every request for a title with zero subtitles was failing instead of returning an empty list.

## Test plan
- [x] `npm test` — same pre-existing unrelated failure on `main` (`formatSubs` local-server-proxy URL test), nothing new introduced by this bump