### PR TITLE
feat: add request logging and log Ktuvit manager call arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,23 @@ You can also add these env variables to alter the way the addon behaves:
 ```bash
 AUTHOR_EMAIL  # The email displayed in the addon's manifest
 PORT   # The port the addon listens on. defaults to 3000
+LOG_LEVEL   # The minimum winston level to log. defaults to http
 ```
+
+#### Logging
+
+Requests are logged by [morgan](https://github.com/expressjs/morgan) at the `http`
+level, and every call to the Ktuvit manager logs its arguments at the `info` level.
+Response bodies are never logged, so a subtitle request shows up as the request
+itself plus its status, never the contents of the SRT file.
+
+`LOG_LEVEL` controls how much of this you see:
+
+| `LOG_LEVEL` | What you get |
+| --- | --- |
+| `info` | Ktuvit calls and errors, no request logs |
+| `http` (default) | The above, plus a line per request |
+| `debug` | The above, plus the results of each Ktuvit call |
 # Contributing
 PRs are more than welcome!
 Take a look at the currently open [issues](https://github.com/maormagori/ktuvit-stremio/issues) to see where you can help. If you're experiencing issues with the addon, be sure to open an issue.

--- a/clients/ktuvit.js
+++ b/clients/ktuvit.js
@@ -13,6 +13,7 @@ const initKtuvitManager = async () => {
     return ktuvit;
   }
 
+  logger.info("Requesting a login cookie from Ktuvit.");
   const loginCookie = await ktuvitManager.getLoginCookie(
     KTUVIT_EMAIL,
     KTUVIT_HASHED_PASS

--- a/common/httpLogger.js
+++ b/common/httpLogger.js
@@ -10,4 +10,4 @@ const httpLogger = morgan(HTTP_LOG_FORMAT, {
   stream: { write: writeToLogger },
 });
 
-module.exports = { httpLogger, HTTP_LOG_FORMAT, writeToLogger };
+module.exports = { httpLogger, writeToLogger };

--- a/common/httpLogger.js
+++ b/common/httpLogger.js
@@ -1,17 +1,9 @@
 const morgan = require("morgan");
 const logger = require("./logger");
 
-// Only request metadata and the response's status/size are formatted here.
-// Response bodies are never logged, which matters most for the /srt/ route:
-// we want a record that a subtitle was requested and whether serving it
-// succeeded, not the contents of the subtitle file itself.
-// Client IPs and user agents are left out as well since they add nothing to a
-// subtitle request but would follow the logs into a future transporter.
 const HTTP_LOG_FORMAT =
   ":method :url :status :res[content-length] - :response-time ms";
 
-// Morgan terminates every line with a newline of its own, and winston adds one
-// when it writes to a transport.
 const writeToLogger = (message) => logger.http(message.trim());
 
 const httpLogger = morgan(HTTP_LOG_FORMAT, {

--- a/common/httpLogger.js
+++ b/common/httpLogger.js
@@ -1,0 +1,21 @@
+const morgan = require("morgan");
+const logger = require("./logger");
+
+// Only request metadata and the response's status/size are formatted here.
+// Response bodies are never logged, which matters most for the /srt/ route:
+// we want a record that a subtitle was requested and whether serving it
+// succeeded, not the contents of the subtitle file itself.
+// Client IPs and user agents are left out as well since they add nothing to a
+// subtitle request but would follow the logs into a future transporter.
+const HTTP_LOG_FORMAT =
+  ":method :url :status :res[content-length] - :response-time ms";
+
+// Morgan terminates every line with a newline of its own, and winston adds one
+// when it writes to a transport.
+const writeToLogger = (message) => logger.http(message.trim());
+
+const httpLogger = morgan(HTTP_LOG_FORMAT, {
+  stream: { write: writeToLogger },
+});
+
+module.exports = { httpLogger, HTTP_LOG_FORMAT, writeToLogger };

--- a/common/logger.js
+++ b/common/logger.js
@@ -1,4 +1,5 @@
 const { createLogger, format, transports } = require("winston");
+const config = require("config");
 
 const customFormat = format.printf((info) => {
   const { level, message, timestamp, stack, ...meta } = info;
@@ -7,7 +8,7 @@ const customFormat = format.printf((info) => {
 });
 
 const logger = createLogger({
-  level: "info",
+  level: config.get("logLevel"),
   format: format.combine(
     format.timestamp({
       format: "DD-MM-YYYY HH:mm:ss",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -5,5 +5,6 @@
     "hashedPassword": "KTUVIT_USER_HASHED_PASSWORD"
   },
   "PORT": "PORT",
+  "logLevel": "LOG_LEVEL",
   "bytesNeededForDetection": "DETECTION_BYTES"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -4,5 +4,6 @@
   "HOSTNAME": "localhost",
   "addonAuthorEmail": "maor@magori.online",
   "enableLocalServerEncoding": false,
+  "logLevel": "http",
   "bytesNeededForDetection": 256
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 require("dotenv").config();
 const logger = require("./common/logger");
+const { httpLogger } = require("./common/httpLogger");
 const config = require("config");
 const express = require("express");
 const cors = require("cors");
@@ -23,6 +24,7 @@ const HOSTNAME = config.get("HOSTNAME");
 
 const addon = express();
 addon.use(cors());
+addon.use(httpLogger);
 
 const respondWithHeaders = function (req, res, next) {
   res.setHeader("Access-Control-Allow-Origin", "*");

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.21.2",
         "fastest-levenshtein": "^1.0.16",
         "ktuvit-api": "^0.4.3",
+        "morgan": "^1.11.0",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -414,7 +415,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -575,6 +575,22 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -1145,7 +1161,6 @@
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2498,6 +2513,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/morgan": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.4.1",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2614,6 +2648,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2791,7 +2833,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
       "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "express": "^4.21.2",
     "fastest-levenshtein": "^1.0.16",
     "ktuvit-api": "^0.4.3",
+    "morgan": "^1.11.0",
     "winston": "^3.8.2"
   }
 }

--- a/routes/downloadSrt.js
+++ b/routes/downloadSrt.js
@@ -37,9 +37,21 @@ const downloadSrtFromKtuvit = (req, res) => {
       return;
     }
 
+    logger.debug("Serving SRT file.", {
+      ktuvitTitleID: titleKtuvitId,
+      ktuvitSubID: subKtuvitId,
+      bytes: Buffer.byteLength(fileContent),
+    });
+
     res.setHeader("Content-Type", "application/x-subrip; charset=utf-8");
     res.end(Buffer.from(fileContent));
   };
+
+  logger.info("Requesting subtitle download from Ktuvit.", {
+    ktuvitTitleID: titleKtuvitId,
+    ktuvitSubID: subKtuvitId,
+    bytesAmountForDetection: DETECTION_BYTES,
+  });
 
   ktuvit
     .downloadSubtitle(titleKtuvitId, subKtuvitId, pipeFile, {

--- a/routes/subs.js
+++ b/routes/subs.js
@@ -21,6 +21,10 @@ const exitEarlyWithEmptySubtitlesArray = (res) => {
 const fetchSubsMiddleware = async (req, res, next) => {
   try {
     const ktuvitFetchedSubs = await fetchSubsFromKtuvit(req.title);
+    logger.debug("Fetched title subs from Ktuvit.", {
+      ktuvitID: req.title?.ktuvitID,
+      subsFound: ktuvitFetchedSubs?.length ?? 0,
+    });
     req.ktuvitSubs = ktuvitFetchedSubs;
     next();
   } catch (err) {
@@ -46,10 +50,17 @@ const extractTitleInfo = async (req, res, next) => {
   const extraArgs = extractExtraArgs(req.params?.query);
 
   try {
+    logger.info("Requesting title's Ktuvit ID.", {
+      type,
+      imdbId: imdbID,
+      season,
+      episode,
+    });
     const ktuvitID = await ktuvit.getKtuvitID({
       type: type,
       imdbId: imdbID,
     });
+    logger.debug("Received title's Ktuvit ID.", { imdbID, ktuvitID });
 
     if (!ktuvitID) {
       exitEarlyWithEmptySubtitlesArray(res);
@@ -90,8 +101,16 @@ const extractExtraArgs = (query) => {
 const fetchSubsFromKtuvit = async (title) => {
   switch (title.type) {
     case type.MOVIE:
+      logger.info("Requesting movie's subs list from Ktuvit.", {
+        ktuvitID: title.ktuvitID,
+      });
       return ktuvit.getSubsIDsListMovie(title.ktuvitID);
     case type.SERIES:
+      logger.info("Requesting episode's subs list from Ktuvit.", {
+        ktuvitID: title.ktuvitID,
+        season: title.season,
+        episode: title.episode,
+      });
       return ktuvit.getSubsIDsListEpisode(
         title.ktuvitID,
         title.season,

--- a/test/e2e/httpLogger.spec.js
+++ b/test/e2e/httpLogger.spec.js
@@ -1,0 +1,135 @@
+const assert = require("assert");
+const http = require("http");
+const express = require("express");
+const { httpLogger } = require("../../common/httpLogger");
+
+const SUBTITLE_TEXT = "SECRET_SUBTITLE_TEXT";
+const SRT_PAYLOAD = `1\n00:00:01,000 --> 00:00:04,000\n${SUBTITLE_TEXT}\n`;
+
+// Replaces process.stdout.write so the assertions run against the line winston
+// actually renders, rather than against the format string or a re-formatted
+// copy of it.
+const captureStdout = () => {
+  const chunks = [];
+  const original = process.stdout.write.bind(process.stdout);
+
+  process.stdout.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+
+  return { chunks, restore: () => (process.stdout.write = original) };
+};
+
+describe("request logging", function () {
+  let server;
+
+  beforeEach(function (done) {
+    const addon = express();
+    addon.use(httpLogger);
+
+    addon.get("/manifest.json", (req, res) =>
+      res.send({ id: "me.stremio.ktuvit" })
+    );
+    addon.get("/srt/:ktuvitId/:subId.srt", (req, res) => {
+      res.setHeader("Content-Type", "application/x-subrip; charset=utf-8");
+      res.end(Buffer.from(SRT_PAYLOAD));
+    });
+
+    server = addon.listen(0, done);
+  });
+
+  afterEach(function (done) {
+    server.close(done);
+  });
+
+  const get = (path, headers) =>
+    new Promise((resolve, reject) => {
+      const req = http.get(
+        // agent: false keeps the socket from being pooled. Node 19 turned
+        // keep-alive on by default, and a pooled socket would leave
+        // server.close() waiting until the afterEach hook times out.
+        { port: server.address().port, path, headers, agent: false },
+        (res) => {
+          res.on("data", () => {});
+          res.on("end", resolve);
+        }
+      );
+      req.on("error", reject);
+    });
+
+  const logOutputFor = async (path, headers) => {
+    const capture = captureStdout();
+
+    try {
+      await get(path, headers);
+    } finally {
+      capture.restore();
+    }
+
+    return capture.chunks;
+  };
+
+  it("should log the method, url, status, response size and duration", async function () {
+    const [line] = await logOutputFor("/manifest.json");
+
+    assert.match(
+      line,
+      /\[http\]: GET \/manifest\.json 200 \d+ - [\d.]+ ms/,
+      `Unexpected log line: ${JSON.stringify(line)}`
+    );
+  });
+
+  it("should log one line per request, with no stray blank line", async function () {
+    const chunks = await logOutputFor("/manifest.json");
+
+    assert.strictEqual(
+      chunks.length,
+      1,
+      `Expected one write, got: ${JSON.stringify(chunks)}`
+    );
+    assert.strictEqual(
+      chunks[0].match(/\n/g).length,
+      1,
+      `Expected a single newline, got: ${JSON.stringify(chunks[0])}`
+    );
+  });
+
+  it("should log an SRT request without any of the subtitle's content", async function () {
+    const [line] = await logOutputFor("/srt/TITLE123/SUB456.srt");
+
+    assert.match(
+      line,
+      /\[http\]: GET \/srt\/TITLE123\/SUB456\.srt 200 (\d+|-) - [\d.]+ ms/
+    );
+
+    for (const payloadFragment of [SUBTITLE_TEXT, "00:00:01,000", "-->"]) {
+      assert.ok(
+        !line.includes(payloadFragment),
+        `Subtitle content should never be logged, found ${payloadFragment} in: ${line}`
+      );
+    }
+  });
+
+  it("should not log the client's address or user agent", async function () {
+    const userAgent = "StremioSniffer/9.9";
+    const [line] = await logOutputFor("/manifest.json", {
+      "User-Agent": userAgent,
+    });
+
+    assert.ok(
+      !line.includes(userAgent),
+      `User agent should not be logged, got: ${line}`
+    );
+    assert.ok(
+      !line.includes("127.0.0.1"),
+      `Client address should not be logged, got: ${line}`
+    );
+  });
+
+  it("should log requests that no route handled", async function () {
+    const [line] = await logOutputFor("/not-a-route");
+
+    assert.match(line, /\[http\]: GET \/not-a-route 404/);
+  });
+});

--- a/test/unit/common/httpLogger.spec.js
+++ b/test/unit/common/httpLogger.spec.js
@@ -1,0 +1,30 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire").noCallThru();
+
+describe("writeToLogger", function () {
+  let mockLogger;
+  let writeToLogger;
+
+  beforeEach(function () {
+    mockLogger = { http: sinon.spy() };
+    ({ writeToLogger } = proxyquire("../../../common/httpLogger", {
+      "./logger": mockLogger,
+    }));
+  });
+
+  it("should log morgan's output at the http level", function () {
+    writeToLogger("GET /manifest.json 200 512 - 3 ms\n");
+
+    assert.ok(mockLogger.http.calledOnce);
+  });
+
+  it("should strip the newline morgan appends, since winston adds its own", function () {
+    writeToLogger("GET /manifest.json 200 512 - 3 ms\n");
+
+    assert.strictEqual(
+      mockLogger.http.firstCall.args[0],
+      "GET /manifest.json 200 512 - 3 ms"
+    );
+  });
+});

--- a/test/unit/common/logger.spec.js
+++ b/test/unit/common/logger.spec.js
@@ -1,0 +1,9 @@
+const assert = require("assert");
+const config = require("config");
+const logger = require("../../../common/logger");
+
+describe("logger", function () {
+  it("should take its level from the configuration", function () {
+    assert.strictEqual(logger.level, config.get("logLevel"));
+  });
+});

--- a/test/unit/routes/downloadSrt.spec.js
+++ b/test/unit/routes/downloadSrt.spec.js
@@ -12,11 +12,25 @@ describe("downloadSrtFromKtuvit", function () {
   let downloadSrtFromKtuvit;
   let initSrtDownloader;
   let mockKtuvit;
+  let mockLogger;
   let res;
+
+  const everythingLogged = () =>
+    JSON.stringify([
+      mockLogger.info.args,
+      mockLogger.debug.args,
+      mockLogger.error.args,
+    ]);
 
   beforeEach(async function () {
     mockKtuvit = {
       downloadSubtitle: sinon.stub(),
+    };
+
+    mockLogger = {
+      info: sinon.spy(),
+      debug: sinon.spy(),
+      error: sinon.spy(),
     };
 
     ({ initSrtDownloader, downloadSrtFromKtuvit } = proxyquire(
@@ -25,6 +39,7 @@ describe("downloadSrtFromKtuvit", function () {
         "../clients/ktuvit": {
           initKtuvitManager: async () => mockKtuvit,
         },
+        "../common/logger": mockLogger,
       }
     ));
 
@@ -130,5 +145,86 @@ describe("downloadSrtFromKtuvit", function () {
     assert.ok(res.setHeader.calledWith("Cache-Control", "no-store"));
     assert.ok(res.status.calledWith(502));
     assert.ok(res.end.notCalled);
+  });
+
+  it("should log the arguments passed to the Ktuvit manager", function () {
+    mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
+      cb(srtWithText(HEBREW_TEXT));
+      return Promise.resolve();
+    });
+
+    const req = { params: { ktuvitId: "TITLE123", subId: "SUB456" } };
+    downloadSrtFromKtuvit(req, res);
+
+    const infoLogged = JSON.stringify(mockLogger.info.args);
+    for (const argument of ["TITLE123", "SUB456", "bytesAmountForDetection"]) {
+      assert.ok(
+        infoLogged.includes(argument),
+        `${argument} should be logged at the info level, got: ${infoLogged}`
+      );
+    }
+  });
+
+  it("should log the served response's size at the debug level, not its content", function () {
+    const srt = srtWithText(HEBREW_TEXT);
+    mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
+      cb(srt);
+      return Promise.resolve();
+    });
+
+    const req = { params: { ktuvitId: "TITLE123", subId: "SUB456" } };
+    downloadSrtFromKtuvit(req, res);
+
+    const debugLogged = JSON.stringify(mockLogger.debug.args);
+
+    assert.ok(
+      debugLogged.includes(`"bytes":${Buffer.byteLength(srt)}`),
+      `Served size should be logged at the debug level, got: ${debugLogged}`
+    );
+
+    for (const subtitleLine of HEBREW_TEXT.split("\n")) {
+      assert.ok(
+        !debugLogged.includes(subtitleLine),
+        `Subtitle content should never be logged, found: ${subtitleLine}`
+      );
+    }
+  });
+
+  it("should log the request but never the SRT payload", function () {
+    mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
+      cb(srtWithText(HEBREW_TEXT));
+      return Promise.resolve();
+    });
+
+    const req = { params: { ktuvitId: "TITLE123", subId: "SUB456" } };
+    downloadSrtFromKtuvit(req, res);
+
+    const logged = everythingLogged();
+    for (const subtitleLine of HEBREW_TEXT.split("\n")) {
+      assert.ok(
+        !logged.includes(subtitleLine),
+        `Subtitle content should never be logged, found: ${subtitleLine}`
+      );
+    }
+  });
+
+  it("should not log the payload of an invalid SRT response either", function () {
+    mockKtuvit.downloadSubtitle.callsFake((titleId, subId, cb) => {
+      cb(KTUVIT_ERROR_MESSAGE);
+      return Promise.resolve();
+    });
+
+    const req = { params: { ktuvitId: "TITLE123", subId: "SUB456" } };
+    downloadSrtFromKtuvit(req, res);
+
+    const logged = everythingLogged();
+    assert.ok(
+      !logged.includes(KTUVIT_ERROR_MESSAGE),
+      "Ktuvit's response body should never be logged"
+    );
+    assert.ok(
+      mockLogger.error.called,
+      "The failure itself should still be logged"
+    );
   });
 });


### PR DESCRIPTION
Closes #19.

Split into 14 small commits, each one reviewable on its own.

## The logging that was added

**morgan for request/response logging** (`common/httpLogger.js`), registered before the routes so it sees every request rather than only the ones no route handles — including 404s and CORS preflights.

It writes into winston rather than to stdout, so there is a single output pipeline for the logging transporter to hook into later. Had it kept its default stream, request logs would stay stranded on fd 1 while everything else got shipped, and you would have Ktuvit call logs in your log service with no record of the requests that triggered them.

The format is custom rather than one of morgan's presets, for two reasons:

- **Response bodies never reach the log.** Per your comment on the issue, an `/srt/` request logs the request and its status, never the subtitle contents.
- **No client IPs or user agents.** They add nothing to a subtitle request, and they are the kind of data you least want following the logs into a transporter. Behind the beamup proxy `:remote-addr` would be the proxy anyway.

**Every call into the Ktuvit manager now logs its arguments:**

| Call | Logged at `info` |
| --- | --- |
| `getKtuvitID` | type, IMDb ID, season, episode |
| `getSubsIDsListMovie` | Ktuvit ID |
| `getSubsIDsListEpisode` | Ktuvit ID, season, episode |
| `downloadSubtitle` | title ID, sub ID, detection byte count |
| `getLoginCookie` | nothing but the attempt — its arguments are the user's email and hashed password |

Results are logged at `debug`: the resolved Ktuvit ID, how many subs came back, and the size of the SRT served — never the subs or the file itself.

## On log levels

Winston orders `http` *below* `info`, so morgan's output would have been silently dropped by the hardcoded `level: "info"`. The logger's level now comes from config and defaults to `http`, with a `LOG_LEVEL` override. That also makes the pre-existing `logger.debug` calls reachable, which they were not before.

| `LOG_LEVEL` | What you get |
| --- | --- |
| `info` | Ktuvit calls and errors, no request logs |
| `http` (default) | The above, plus a line per request |
| `debug` | The above, plus the results of each Ktuvit call |

Sample output:

```
17-08-2026 11:19:57 [info]: Requesting title's Ktuvit ID. {"type":"series","imdbId":"tt0903747","season":"2","episode":"5"}
17-08-2026 11:19:57 [info]: Requesting episode's subs list from Ktuvit. {"ktuvitID":"KT-tt0903747","season":"2","episode":"5"}
17-08-2026 11:19:57 [http]: GET /subtitles/series/tt0903747:2:5/filename=....json 200 412 - 1.9 ms
17-08-2026 11:19:57 [http]: GET /srt/KT-tt0903747/SUB2.srt 200 - - 0.3 ms
```

## The tests that were added

`npm test` goes from **9 to 21 passing**. The `test/**/*.spec.js` glob already picks up the new directory, so no script change was needed.

**`test/e2e/httpLogger.spec.js`** — 5 integration tests, a new `test/e2e/` directory alongside the existing `test/unit/`. These mount the middleware on a real express app, make real HTTP requests, and assert the line **winston actually renders**, captured by replacing `process.stdout.write`:

- all five format tokens, via `/\[http\]: GET \/manifest\.json 200 \d+ - [\d.]+ ms/`
- one line per request with no stray blank line
- an SRT request logs no subtitle content, no `-->`, no timestamp line
- a request sending `User-Agent: StremioSniffer/9.9` logs neither it nor the client address
- a 404 is logged, which only works because the middleware is registered before the routes

**`test/unit/common/httpLogger.spec.js`** — 2 tests: `writeToLogger` logs at the `http` level, and strips the newline morgan appends so winston's own newline does not leave a blank line after every request.

**`test/unit/common/logger.spec.js`** — 1 test: the logger takes its level from configuration. Without it, a revert to a hardcoded level would silently drop every request log.

**`test/unit/routes/downloadSrt.spec.js`** — 4 tests added, one per level plus the two payload guarantees. The logger is now stubbed here, which also keeps winston's real error stack traces out of the test output:

- the arguments passed to `downloadSubtitle` are logged at `info`, asserted against the info spy specifically since the default level hides `debug`
- the served response's size is logged at `debug` and its content is not
- a successfully served subtitle never reaches the log
- neither does the body of an invalid SRT response — the tempting one to log while debugging, and that branch also fires on a truncated subtitle, so the body there can be real subtitle content

Every new test was mutation-checked rather than assumed to work. Dropping tokens from the format fails 3 e2e tests; removing `.trim()` fails the e2e newline test and the unit test; moving the argument logging from `info` to `debug` fails the args test; swapping `Buffer.byteLength` for `.length` fails the size test; leaking the payload into a log call fails the payload tests. Each mutation was reverted after checking.

## Notes

- The e2e suite passed 60 consecutive runs with no flakes. It needs no wait after each request: winston writes synchronously inside morgan's response `finish` handler, and the server finishes sending before the client can see `end`.
- `http.get` in the e2e helper passes `agent: false` on purpose. Node 19 turned keep-alive on by default, and a pooled socket would leave `server.close()` waiting until the `afterEach` hook times out — so without it these tests would pass on Node 16 and hang on anything newer.
- Pre-existing prettier violations in `routes/subs.js`, `routes/downloadSrt.js` and `downloadSrt.spec.js` are left alone to keep the diff readable; none of the new lines add any.
- The spec files trip `no-undef` on mocha's globals, as the existing ones already do — `.eslintrc.json` has no `"mocha": true` in `env`. Happy to add it here or leave it for a separate PR.
- Unrelated, spotted while reading: `initKtuvitManager` in `clients/ktuvit.js` has no `return ktuvit` on its first pass, so it returns `undefined` unless something already initialised it. It works today only because `index.js` calls it before `initSubs`/`initSrtDownloader`. Happy to send that as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
