### PR TITLE
ci: lint and test every pull request

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,14 @@
   },
   "plugins": ["prettier"],
   "extends": ["eslint:recommended","plugin:prettier/recommended"],
-  "overrides": [],
+  "overrides": [
+    {
+      "files": ["test/**/*.spec.js"],
+      "env": {
+        "mocha": true
+      }
+    }
+  ],
   "parserOptions": {
     "ecmaVersion": "latest"
   },

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
       - name: Install dependencies
         run: npm ci
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["18.x", "20.x", "22.x"]
+        node-version: ["22.x"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,43 @@
+# A GitHub workflow that makes sure the PR passes linting and tests before merging
+
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["18.x", "20.x", "22.x"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.2",
   "description": "An unofficial Stremio addon for ktuvit.me",
   "main": "index.js",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "test": "KTUVIT_USER_EMAIL=test KTUVIT_USER_HASHED_PASSWORD=test mocha 'test/**/*.spec.js'",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "KTUVIT_USER_EMAIL=test KTUVIT_USER_HASHED_PASSWORD=test mocha 'test/**/*.spec.js'",
+    "lint": "eslint .",
+    "fix": "npm run lint -- --fix",
     "start": "node index.js",
     "devStart": "nodemon index.js"
   },

--- a/routes/downloadSrt.js
+++ b/routes/downloadSrt.js
@@ -7,7 +7,8 @@ const DETECTION_BYTES = config.get("bytesNeededForDetection");
 // Ktuvit sometimes returns an error message (e.g. an expired download
 // identifier) with a 200 status instead of actual subtitle content. Requiring
 // a timestamp line catches that case regardless of the exact wording.
-const SRT_TIMESTAMP_PATTERN = /\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/;
+const SRT_TIMESTAMP_PATTERN =
+  /\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/;
 
 let ktuvit;
 const initSrtDownloader = async () => {

--- a/routes/subs.js
+++ b/routes/subs.js
@@ -113,7 +113,8 @@ const formatSubs = (req, res) => {
       id: `[KTUVIT]${ktuvitSub.subName}`,
       lang: "heb",
       url: config.get("enableLocalServerEncoding")
-        ? LOCAL_SERVER_ENCODER_URL + formatSrtUrl(req.title.ktuvitID, ktuvitSub.id)
+        ? LOCAL_SERVER_ENCODER_URL +
+          formatSrtUrl(req.title.ktuvitID, ktuvitSub.id)
         : formatSrtUrl(req.title.ktuvitID, ktuvitSub.id),
     });
   }

--- a/test/unit/routes/downloadSrt.spec.js
+++ b/test/unit/routes/downloadSrt.spec.js
@@ -2,8 +2,7 @@ const assert = require("assert");
 const sinon = require("sinon");
 const proxyquire = require("proxyquire").noCallThru();
 
-const srtWithText = (text) =>
-  `1\n00:00:01,000 --> 00:00:04,000\n${text}\n`;
+const srtWithText = (text) => `1\n00:00:01,000 --> 00:00:04,000\n${text}\n`;
 
 const HEBREW_TEXT = "שלום עולם\nThis is a Hebrew subtitle line.";
 const KTUVIT_ERROR_MESSAGE = "הבקשה לא נמצאה, נא לנסות להוריד את הקובץ בשנית";
@@ -80,7 +79,10 @@ describe("downloadSrtFromKtuvit", function () {
     downloadSrtFromKtuvit(req, res);
 
     assert.ok(
-      res.setHeader.calledWith("Content-Type", "application/x-subrip; charset=utf-8")
+      res.setHeader.calledWith(
+        "Content-Type",
+        "application/x-subrip; charset=utf-8"
+      )
     );
   });
 
@@ -99,7 +101,10 @@ describe("downloadSrtFromKtuvit", function () {
     assert.ok(res.setHeader.calledWith("Cache-Control", "no-store"));
     assert.ok(res.status.calledWith(502));
     assert.ok(res.send.called);
-    assert.ok(res.end.notCalled, "Invalid content should never be sent as the response body");
+    assert.ok(
+      res.end.notCalled,
+      "Invalid content should never be sent as the response body"
+    );
   });
 
   it("should reject with a non-cacheable error when the download callback reports an error", function () {


### PR DESCRIPTION
Closes #12.

Adds a `PR Validation` workflow so every pull request gets linted and tested before merge. Modelled on the one in the Wizdom addon so the two repos behave the same way.

Three commits: the eslint fix that makes a lint gate possible, the formatting it exposed, then the workflow itself.

## Why two commits before the workflow

`eslint .` did not pass on `main`, so a lint gate would have failed the moment it was added. 18 errors, in two groups:

- **13 `no-undef`** on `describe`, `it` and `beforeEach`. `.eslintrc.json` declared no mocha environment. Fixed with an `overrides` entry scoped to `test/**/*.spec.js` rather than enabling mocha globally, so source files still cannot reach for those globals by accident.
- **5 `prettier/prettier`** violations in `routes/subs.js`, `routes/downloadSrt.js` and `test/unit/routes/downloadSrt.spec.js`. Fixed with `eslint . --fix`, so the change is line wrapping only — no statement, condition or assertion is different, and the suite still passes.

## The workflow

Two jobs, matching the Wizdom naming:

| Job | Runs |
| --- | --- |
| `Lint` | `npm run lint` on Node 22 |
| `Test (Node 22.x)` | `npm test` |

Also adds the `lint` and `fix` scripts the workflow calls, named as in the Wizdom addon:

```json
"lint": "eslint .",
"fix": "npm run lint -- --fix"
```

`package.json` also gains an `engines` field, so the version we deploy is an explicit fact rather than an implicit buildpack default:

```json
"engines": { "node": "22.x" }
```

There is no `engine-strict` in the repo, so this is advisory: a contributor on a different Node gets an `EBADENGINE` warning, not a failed install. Happy to make it hard-fail if you would rather.

## Differences from the Wizdom workflow, and why

- **`actions/checkout@v4` and `actions/setup-node@v4`** instead of `v2`. The v2 actions are deprecated and already emit warnings on GitHub's runners.
- **`npm ci` instead of `npm install`**, so a run installs exactly what `package-lock.json` pins rather than silently picking up newer minors — which is the point of a gate that says "nothing is broken". `setup-node`'s npm cache is enabled to keep it quick.
- **Both jobs pinned to Node 22**, the version we run in production. This started out as an 18/20/22 matrix; @maormagori pointed out that prod is 22 and that testing versions we do not ship is overhead, so the matrix is now `["22.x"]` and lint moved off 20. The `matrix` block is kept rather than flattened, so adding a version back is a one-line change and the job keeps its `Test (Node 22.x)` name. Worth noting separately: mocha 11 requires `^18.18.0 || ^20.9.0 || >=21.1.0`, so the README saying Node 14 is stale either way.

Linting runs once rather than per-version, since its result does not depend on the runtime.

## Verified locally

```
npm run lint   → clean
npm test       → 9 passing
npm ci         → succeeds from the lockfile
```

The workflow YAML was parsed to confirm it produces the intended jobs, triggers and matrix.

## Notes

- The workflow triggers on `pull_request` against `main`, so it should run on this PR itself. As this is my first PR here, GitHub may hold the run until a maintainer approves workflows for a first-time contributor.
- This touches `routes/subs.js`, `routes/downloadSrt.js` and `test/unit/routes/downloadSrt.spec.js`, which #78 also touches. The overlap is formatting-only and in different regions, but whichever merges second may want a quick rebase. Happy to rebase this one on top of #78 if you would rather merge that first.
- Only the 5 violations that `eslint .` reports are fixed. `prettier --check .` also flags several JSON, YAML and Markdown files, but eslint does not gate those, so they are left alone to keep this diff small. Worth its own PR if you want the whole repo prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

