### PR TITLE
feat: cache subtitles lists per title

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,23 @@ You can also add these env variables to alter the way the addon behaves:
 ```bash
 AUTHOR_EMAIL  # The email displayed in the addon's manifest
 PORT   # The port the addon listens on. defaults to 3000
+SUBS_CACHE_MAX_ENTRIES    # How many titles to keep cached. defaults to 500
+SUBS_CACHE_FOUND_TTL_MS   # How long to keep a subtitles list. defaults to 3600000 (1 hour)
+SUBS_CACHE_EMPTY_TTL_MS   # How long to keep an empty result. defaults to 300000 (5 minutes)
 ```
+
+#### Caching
+
+Stremio appends the video's filename, hash and size to every subtitles request,
+so no two viewers of the same episode send the same URL and route based caching
+never helps. The addon therefore caches subtitles lists itself, keyed on the
+title rather than the URL: every release of one episode shares a single entry
+and each request is still sorted against its own filename.
+
+An empty result is kept only briefly, since it usually means the subtitles are
+not up yet rather than that the title will never have any. Failed requests are
+never cached. The cache is per process, so it starts empty after a restart.
+
 # Contributing
 PRs are more than welcome!
 Take a look at the currently open [issues](https://github.com/maormagori/ktuvit-stremio/issues) to see where you can help. If you're experiencing issues with the addon, be sure to open an issue.

--- a/common/subsCache.js
+++ b/common/subsCache.js
@@ -1,0 +1,68 @@
+const { LRUCache } = require("lru-cache");
+const config = require("config");
+const logger = require("./logger");
+
+const MAX_ENTRIES = Number(config.get("subsCache.maxEntries"));
+const FOUND_TTL = Number(config.get("subsCache.foundTtlMs"));
+const EMPTY_TTL = Number(config.get("subsCache.emptyTtlMs"));
+
+const cache = new LRUCache({ max: MAX_ENTRIES, ttl: FOUND_TTL });
+
+// Keyed on exactly what fetchSubsFromKtuvit passes to Ktuvit: the type decides
+// which endpoint is called, and the Ktuvit ID with the season and episode are
+// its arguments. Stremio's filename, hash and size are what make every URL
+// unique and route based caching useless, and none of them reach the key, so
+// two releases of one episode share an entry and each request still gets its
+// own ordering from sortSubsByFilename afterwards.
+const keyFor = (title) => {
+  const parts = [title.type, title.ktuvitID];
+
+  if (title.season !== undefined) {
+    parts.push(title.season);
+  }
+  if (title.episode !== undefined) {
+    parts.push(title.episode);
+  }
+
+  return parts.join(":");
+};
+
+// Handed out as a copy so that a caller sorting the list in place cannot
+// reorder what the next request will read.
+const copyOf = (subs) => (Array.isArray(subs) ? [...subs] : subs);
+
+const getOrFetch = async (title, fetchSubs) => {
+  const key = keyFor(title);
+  const cached = cache.get(key);
+
+  if (cached) {
+    logger.debug("Subs cache hit.", { key });
+    return copyOf(await cached);
+  }
+
+  logger.debug("Subs cache miss.", { key });
+
+  // The pending promise is cached, not just its result, so requests that
+  // arrive while the first one is still in flight share it instead of each
+  // starting their own fetch. A newly released episode gets asked for by many
+  // clients at once, which is exactly when that matters.
+  const pending = fetchSubs();
+  cache.set(key, pending);
+
+  try {
+    const subs = await pending;
+    // An empty list expires quickly: it usually means the subs are not up yet,
+    // not that this title will never have any.
+    cache.set(key, subs, {
+      ttl: Array.isArray(subs) && subs.length ? FOUND_TTL : EMPTY_TTL,
+    });
+    return copyOf(subs);
+  } catch (err) {
+    // A failed fetch is never cached. Keeping it would turn one bad response
+    // from Ktuvit into an empty subtitles list for everyone until it expired.
+    cache.delete(key);
+    throw err;
+  }
+};
+
+module.exports = { getOrFetch };

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -5,5 +5,10 @@
     "hashedPassword": "KTUVIT_USER_HASHED_PASSWORD"
   },
   "PORT": "PORT",
-  "bytesNeededForDetection": "DETECTION_BYTES"
+  "bytesNeededForDetection": "DETECTION_BYTES",
+  "subsCache": {
+    "maxEntries": "SUBS_CACHE_MAX_ENTRIES",
+    "foundTtlMs": "SUBS_CACHE_FOUND_TTL_MS",
+    "emptyTtlMs": "SUBS_CACHE_EMPTY_TTL_MS"
+  }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -4,5 +4,10 @@
   "HOSTNAME": "localhost",
   "addonAuthorEmail": "maor@magori.online",
   "enableLocalServerEncoding": false,
-  "bytesNeededForDetection": 256
+  "bytesNeededForDetection": 256,
+  "subsCache": {
+    "maxEntries": 500,
+    "foundTtlMs": 3600000,
+    "emptyTtlMs": 300000
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.21.2",
         "fastest-levenshtein": "^1.0.16",
         "ktuvit-api": "^0.4.3",
+        "lru-cache": "^10.4.3",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -414,7 +415,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1145,7 +1145,6 @@
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2285,9 +2284,7 @@
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -2791,7 +2788,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
       "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "express": "^4.21.2",
     "fastest-levenshtein": "^1.0.16",
     "ktuvit-api": "^0.4.3",
+    "lru-cache": "^10.4.3",
     "winston": "^3.8.2"
   }
 }

--- a/routes/subs.js
+++ b/routes/subs.js
@@ -1,5 +1,6 @@
 const { initKtuvitManager } = require("../clients/ktuvit");
 const { type } = require("../common/ktuvitEnums");
+const { getOrFetch } = require("../common/subsCache");
 const logger = require("../common/logger");
 const config = require("config");
 const { distance } = require("fastest-levenshtein");
@@ -20,7 +21,9 @@ const exitEarlyWithEmptySubtitlesArray = (res) => {
 
 const fetchSubsMiddleware = async (req, res, next) => {
   try {
-    const ktuvitFetchedSubs = await fetchSubsFromKtuvit(req.title);
+    const ktuvitFetchedSubs = await getOrFetch(req.title, () =>
+      fetchSubsFromKtuvit(req.title)
+    );
     req.ktuvitSubs = ktuvitFetchedSubs;
     next();
   } catch (err) {

--- a/test/unit/common/subsCache.spec.js
+++ b/test/unit/common/subsCache.spec.js
@@ -1,0 +1,368 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire").noCallThru();
+
+const FOUND_TTL = 60000;
+const EMPTY_TTL = 5000;
+
+const SUBS = [
+  { id: "SUB1", subName: "Freies.Land.2019.D.BDRip.1.46Gb.MegaPeer.avi.srt" },
+  { id: "SUB2", subName: "Freies.Land.2019.DVDRIP.MegaPeer.avi.srt" },
+];
+
+// Shaped like the req.title that extractTitleInfo builds: season and episode
+// are strings for a series and present but undefined for a movie, and the
+// resolved ktuvitID always comes along.
+const movie = (overrides = {}) => ({
+  type: "movie",
+  imdbID: "tt9407490",
+  season: undefined,
+  episode: undefined,
+  ktuvitID: "KT9407490",
+  ...overrides,
+});
+
+const episode = (overrides = {}) => ({
+  type: "series",
+  imdbID: "tt0903747",
+  season: "2",
+  episode: "5",
+  ktuvitID: "KT0903747",
+  ...overrides,
+});
+
+// The arguments Stremio appends to every subtitles request. They differ per
+// viewer and must never split a cache entry.
+const release = (title, filename, videoHash, videoSize) => ({
+  ...title,
+  filename,
+  videoHash,
+  videoSize,
+});
+
+// Every fetch hands back its own array so that a test mutating a result cannot
+// change the fixture the next assertion relies on.
+const countingFetch = (subs = SUBS) =>
+  sinon.stub().callsFake(async () => [...subs]);
+
+const loadCache = (overrides = {}) => {
+  const values = {
+    "subsCache.maxEntries": 500,
+    "subsCache.foundTtlMs": FOUND_TTL,
+    "subsCache.emptyTtlMs": EMPTY_TTL,
+    ...overrides,
+  };
+
+  return proxyquire("../../../common/subsCache", {
+    config: { get: (key) => values[key] },
+    "./logger": { debug: sinon.spy(), info: sinon.spy(), error: sinon.spy() },
+  });
+};
+
+const SHARE_ONE_FETCH = [
+  {
+    what: "a movie asked for by two different releases",
+    first: release(
+      movie(),
+      "Freies.Land.2019.D.BDRip.1.46Gb.MegaPeer.avi",
+      "fe4032afd8b70beb",
+      "1567260672"
+    ),
+    second: release(
+      movie(),
+      "Freies.Land.2019.DVDRIP.MegaPeer.avi",
+      "fe40328b70beb",
+      "1401229312"
+    ),
+  },
+  {
+    what: "a movie asked for twice by the same release",
+    first: release(movie(), "Freies.Land.2019.DVDRIP.avi", "aaa", "1"),
+    second: release(movie(), "Freies.Land.2019.DVDRIP.avi", "aaa", "1"),
+  },
+  {
+    what: "a movie with no extra arguments at all",
+    first: movie(),
+    second: movie(),
+  },
+  {
+    what: "a movie whose undefined season and episode keys are absent instead",
+    first: movie(),
+    second: { type: "movie", imdbID: "tt9407490", ktuvitID: "KT9407490" },
+  },
+  {
+    what: "an episode asked for by two different releases",
+    first: release(
+      episode(),
+      "Breaking.Bad.S02E05.1080p.WEB-DL.mkv",
+      "abc123",
+      "1567260672"
+    ),
+    second: release(
+      episode(),
+      "Breaking.Bad.S02E05.720p.HDTV.x264.mkv",
+      "def456",
+      "734003200"
+    ),
+  },
+  {
+    what: "an episode asked for with and without extra arguments",
+    first: episode(),
+    second: release(episode(), "Breaking.Bad.S02E05.BluRay.mkv", "ghi789", "2"),
+  },
+  {
+    what: "one title reached through two different imdb ids",
+    first: movie(),
+    second: movie({ imdbID: "tt9999999" }),
+  },
+];
+
+const NEED_THEIR_OWN_FETCH = [
+  {
+    what: "two different movies",
+    first: movie(),
+    second: movie({ imdbID: "tt0111161", ktuvitID: "KT0111161" }),
+  },
+  {
+    what: "two episodes of the same season",
+    first: episode(),
+    second: episode({ episode: "6" }),
+  },
+  {
+    what: "the same episode number in two seasons",
+    first: episode(),
+    second: episode({ season: "3" }),
+  },
+  {
+    what: "the same season and episode of two different series",
+    first: episode(),
+    second: episode({ imdbID: "tt0944947", ktuvitID: "KT0944947" }),
+  },
+  {
+    what: "one imdb id that now resolves to a different ktuvit id",
+    first: movie(),
+    second: movie({ ktuvitID: "KT9407490_REINDEXED" }),
+  },
+  {
+    what: "the same ktuvit id with nothing but the type to tell them apart",
+    first: { type: "movie", ktuvitID: "KT0903747" },
+    second: { type: "series", ktuvitID: "KT0903747" },
+  },
+  {
+    what: "two releases of two different movies",
+    first: release(movie(), "Freies.Land.2019.BDRip.avi", "aaa", "1"),
+    second: release(
+      movie({ imdbID: "tt0111161", ktuvitID: "KT0111161" }),
+      "Shawshank.1994.BDRip.avi",
+      "bbb",
+      "2"
+    ),
+  },
+];
+
+describe("subsCache getOrFetch", function () {
+  let getOrFetch;
+
+  beforeEach(function () {
+    ({ getOrFetch } = loadCache());
+  });
+
+  SHARE_ONE_FETCH.forEach(({ what, first, second }) => {
+    it(`should ask Ktuvit once for ${what}`, async function () {
+      const fetchSubs = countingFetch();
+
+      const firstSubs = await getOrFetch(first, fetchSubs);
+      const secondSubs = await getOrFetch(second, fetchSubs);
+
+      assert.strictEqual(
+        fetchSubs.callCount,
+        1,
+        `Expected one Ktuvit call for ${what}, got ${fetchSubs.callCount}`
+      );
+      assert.deepStrictEqual(firstSubs, SUBS);
+      assert.deepStrictEqual(secondSubs, SUBS);
+    });
+  });
+
+  NEED_THEIR_OWN_FETCH.forEach(({ what, first, second }) => {
+    it(`should ask Ktuvit twice for ${what}`, async function () {
+      const fetchSubs = countingFetch();
+
+      await getOrFetch(first, fetchSubs);
+      await getOrFetch(second, fetchSubs);
+
+      assert.strictEqual(
+        fetchSubs.callCount,
+        2,
+        `Expected two Ktuvit calls for ${what}, got ${fetchSubs.callCount}`
+      );
+    });
+  });
+
+  it("should ask Ktuvit once however many releases of one episode arrive", async function () {
+    const fetchSubs = countingFetch();
+    const releases = [
+      "Breaking.Bad.S02E05.1080p.WEB-DL.mkv",
+      "Breaking.Bad.S02E05.720p.HDTV.x264.mkv",
+      "Breaking.Bad.S02E05.BluRay.x264-GROUP.mkv",
+      "Breaking.Bad.S02E05.DVDRip.XviD.avi",
+      "Breaking.Bad.S02E05.2160p.HDR.mkv",
+    ];
+
+    for (const filename of releases) {
+      await getOrFetch(episode({ filename }), fetchSubs);
+    }
+
+    assert.strictEqual(
+      fetchSubs.callCount,
+      1,
+      `Expected 1 Ktuvit call for ${releases.length} releases, got ${fetchSubs.callCount}`
+    );
+  });
+
+  it("should share one fetch between requests that arrive together", async function () {
+    let resolveFetch;
+    const fetchSubs = sinon
+      .stub()
+      .returns(new Promise((resolve) => (resolveFetch = resolve)));
+
+    const inFlight = Promise.all([
+      getOrFetch(episode(), fetchSubs),
+      getOrFetch(episode(), fetchSubs),
+      getOrFetch(episode(), fetchSubs),
+    ]);
+    resolveFetch(SUBS);
+    const results = await inFlight;
+
+    assert.strictEqual(
+      fetchSubs.callCount,
+      1,
+      "Requests arriving before the first one resolves should reuse it"
+    );
+    results.forEach((subs) => assert.deepStrictEqual(subs, SUBS));
+  });
+
+  it("should not cache a failed fetch", async function () {
+    const fetchSubs = sinon.stub();
+    fetchSubs.onFirstCall().rejects(new Error("ktuvit is down"));
+    fetchSubs.onSecondCall().callsFake(async () => [...SUBS]);
+
+    await assert.rejects(() => getOrFetch(movie(), fetchSubs));
+    const subs = await getOrFetch(movie(), fetchSubs);
+
+    assert.strictEqual(
+      fetchSubs.callCount,
+      2,
+      "A failure must not be remembered as this title's subtitles"
+    );
+    assert.deepStrictEqual(subs, SUBS);
+  });
+
+  it("should hand out a copy so a caller cannot reorder the cached list", async function () {
+    const expectedOrder = SUBS.map((sub) => sub.id);
+    const fetchSubs = countingFetch();
+
+    const first = await getOrFetch(movie(), fetchSubs);
+    first.reverse();
+
+    const second = await getOrFetch(movie(), fetchSubs);
+
+    assert.deepStrictEqual(
+      second.map((sub) => sub.id),
+      expectedOrder,
+      "Sorting the returned array must not affect what the next request reads"
+    );
+  });
+
+  it("should evict the least recently used title once it is full", async function () {
+    ({ getOrFetch } = loadCache({ "subsCache.maxEntries": 2 }));
+    const fetchSubs = countingFetch();
+
+    await getOrFetch(movie({ ktuvitID: "KT1" }), fetchSubs);
+    await getOrFetch(movie({ ktuvitID: "KT2" }), fetchSubs);
+    await getOrFetch(movie({ ktuvitID: "KT3" }), fetchSubs);
+    await getOrFetch(movie({ ktuvitID: "KT1" }), fetchSubs);
+
+    assert.strictEqual(
+      fetchSubs.callCount,
+      4,
+      "The oldest title should have been evicted, forcing a refetch"
+    );
+  });
+});
+
+describe("subsCache getOrFetch expiry", function () {
+  let getOrFetch;
+  let clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+    ({ getOrFetch } = loadCache());
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it("should keep a found list for the whole found ttl", async function () {
+    const fetchSubs = countingFetch();
+
+    await getOrFetch(movie(), fetchSubs);
+    clock.tick(FOUND_TTL - 1);
+    await getOrFetch(movie(), fetchSubs);
+
+    assert.strictEqual(
+      fetchSubs.callCount,
+      1,
+      "A found list should still be served just before its ttl"
+    );
+  });
+
+  it("should refetch a found list once the found ttl passes", async function () {
+    const fetchSubs = countingFetch();
+
+    await getOrFetch(movie(), fetchSubs);
+    clock.tick(FOUND_TTL + 1);
+    await getOrFetch(movie(), fetchSubs);
+
+    assert.strictEqual(fetchSubs.callCount, 2);
+  });
+
+  it("should outlive the empty ttl when subtitles were found", async function () {
+    const fetchSubs = countingFetch();
+
+    await getOrFetch(movie(), fetchSubs);
+    clock.tick(EMPTY_TTL + 1);
+    await getOrFetch(movie(), fetchSubs);
+
+    assert.strictEqual(
+      fetchSubs.callCount,
+      1,
+      "The short ttl is only meant for empty results"
+    );
+  });
+
+  it("should keep an empty list only until the empty ttl", async function () {
+    const fetchSubs = countingFetch([]);
+
+    await getOrFetch(episode(), fetchSubs);
+    clock.tick(EMPTY_TTL - 1);
+    await getOrFetch(episode(), fetchSubs);
+
+    assert.strictEqual(
+      fetchSubs.callCount,
+      1,
+      "Should still be served just before the empty ttl"
+    );
+  });
+
+  it("should retry an empty list soon after, the subs may not be up yet", async function () {
+    const fetchSubs = countingFetch([]);
+
+    await getOrFetch(episode(), fetchSubs);
+    clock.tick(EMPTY_TTL + 1);
+    await getOrFetch(episode(), fetchSubs);
+
+    assert.strictEqual(fetchSubs.callCount, 2);
+  });
+});

--- a/test/unit/common/subsCache.spec.js
+++ b/test/unit/common/subsCache.spec.js
@@ -45,6 +45,13 @@ const release = (title, filename, videoHash, videoSize) => ({
 const countingFetch = (subs = SUBS) =>
   sinon.stub().callsFake(async () => [...subs]);
 
+// lru-cache resolves its clock at require time, so a test that installs a fake
+// one has to make it load again afterwards. Only the expiry suite needs this.
+const forgetLruCache = () =>
+  Object.keys(require.cache)
+    .filter((file) => file.includes("lru-cache"))
+    .forEach((file) => delete require.cache[file]);
+
 const loadCache = (overrides = {}) => {
   const values = {
     "subsCache.maxEntries": 500,
@@ -297,11 +304,26 @@ describe("subsCache getOrFetch expiry", function () {
 
   beforeEach(function () {
     clock = sinon.useFakeTimers();
+    // lru-cache reads the clock through the global performance object, which
+    // it captures once when it is first required. sinon replaces that object
+    // rather than patching it, so a copy loaded before the fake clock went in
+    // keeps reading the real one and never sees a tick. Drop it from the
+    // require cache so the copy subsCache loads here reads the fake clock.
+    forgetLruCache();
+    // lru-cache stores the time an entry was cached and treats a zero
+    // timestamp as "no expiry set". The fake clock starts performance.now() at
+    // zero, so move it off zero before anything is cached, or every entry
+    // would look permanently fresh.
+    clock.tick(1);
     ({ getOrFetch } = loadCache());
   });
 
   afterEach(function () {
     clock.restore();
+    // The copy loaded above is holding the fake performance object, which stops
+    // advancing once the clock is restored. Drop it again so whatever loads
+    // lru-cache next starts from the real clock.
+    forgetLruCache();
   });
 
   it("should keep a found list for the whole found ttl", async function () {

--- a/test/unit/routes/subs.spec.js
+++ b/test/unit/routes/subs.spec.js
@@ -55,3 +55,93 @@ describe("formatSubs", function () {
     assert.deepStrictEqual(subtitles, []);
   });
 });
+
+describe("fetchSubsMiddleware", function () {
+  const proxyquire = require("proxyquire").noCallThru();
+
+  const SUBS = [{ id: "SUB1", subName: "Freies.Land.2019.DVDRIP.avi.srt" }];
+
+  const titleFor = (filename) => ({
+    type: "movie",
+    imdbID: "tt9407490",
+    season: undefined,
+    episode: undefined,
+    ktuvitID: "KT9407490",
+    filename,
+  });
+
+  let fetchSubsMiddleware;
+  let getSubsIDsListMovie;
+
+  beforeEach(async function () {
+    getSubsIDsListMovie = sinon.stub().callsFake(async () => [...SUBS]);
+
+    const subs = proxyquire("../../../routes/subs", {
+      "../clients/ktuvit": {
+        initKtuvitManager: async () => ({ getSubsIDsListMovie }),
+      },
+      "../common/logger": {
+        debug: sinon.spy(),
+        info: sinon.spy(),
+        error: sinon.spy(),
+      },
+      "../common/subsCache": proxyquire("../../../common/subsCache", {
+        config: {
+          get: (key) =>
+            ({
+              "subsCache.maxEntries": 500,
+              "subsCache.foundTtlMs": 60000,
+              "subsCache.emptyTtlMs": 5000,
+            }[key]),
+        },
+        "./logger": {
+          debug: sinon.spy(),
+          info: sinon.spy(),
+          error: sinon.spy(),
+        },
+      }),
+    });
+
+    ({ fetchSubsMiddleware } = subs);
+    await subs.initSubs();
+  });
+
+  const callWith = async (filename) => {
+    const req = { title: titleFor(filename) };
+    await fetchSubsMiddleware(req, { send: sinon.spy() }, () => {});
+    return req;
+  };
+
+  it("should ask Ktuvit once for two viewers watching different releases", async function () {
+    await callWith("Freies.Land.2019.D.BDRip.1.46Gb.MegaPeer.avi");
+    await callWith("Freies.Land.2019.DVDRIP.MegaPeer.avi");
+
+    assert.strictEqual(
+      getSubsIDsListMovie.callCount,
+      1,
+      "The second viewer should have been served from the cache"
+    );
+  });
+
+  it("should still put the subs on the request when they come from the cache", async function () {
+    await callWith("Freies.Land.2019.D.BDRip.avi");
+    const second = await callWith("Freies.Land.2019.DVDRIP.avi");
+
+    assert.deepStrictEqual(second.ktuvitSubs, SUBS);
+  });
+
+  it("should fall back to an empty list when Ktuvit fails, without caching it", async function () {
+    getSubsIDsListMovie.onFirstCall().rejects(new Error("ktuvit is down"));
+
+    const failed = await callWith("Freies.Land.2019.D.BDRip.avi");
+    assert.deepStrictEqual(failed.ktuvitSubs, []);
+
+    const retried = await callWith("Freies.Land.2019.DVDRIP.avi");
+    assert.deepStrictEqual(retried.ktuvitSubs, SUBS);
+    assert.strictEqual(
+      getSubsIDsListMovie.callCount,
+      2,
+      "A failure must not be cached as this title's subtitles"
+    );
+  });
+});


### PR DESCRIPTION
Closes #14.

Subtitles lists are now cached, keyed on the title rather than the URL, so the two requests you pasted into the issue cost one Ktuvit call between them instead of one each.

## What I measured first

Against the live addon, to confirm the problem and to avoid rebuilding anything that already works:

```
same title, filename A (1st):  MISS
same title, filename A (2nd):  HIT      <- the edge does cache, per exact URL
same title, filename B (1st):  MISS     <- identical data, new URL, straight to origin
```

Cloudflare fronts the addon with `max-age=14400`, so URL caching exists, it just never helps: every viewer sends a different `filename`, so almost every real request is a MISS.

Two other findings that shaped the change:

- **SRT files are already cached**, which answers the "we still got to make sure of that" in the issue. A live `/srt/` URL returns `cf-cache-status: HIT` on the second request. They are also ~128KB each, so caching them in process memory would be the worst trade available: most memory, for a benefit we already get free. Left alone.
- **`ktuvit-api` already caches the imdb-to-Ktuvit-ID lookup** in process for 12 hours, and that is the two-round-trip call (an IMDb name lookup plus a Ktuvit search). So the ID resolution needed nothing either.

That leaves exactly one gap: the subtitles list, one GET plus a jsdom parse of Ktuvit's HTML, on every single request.

## The key

Keyed on exactly what `fetchSubsFromKtuvit` passes to Ktuvit:

```
movie:KT9407490
series:KT0903747:2:5
```

The type decides which endpoint is called, and the Ktuvit ID with the season and episode are its arguments. `filename`, `videoHash` and `videoSize` never reach the key, which is the whole point, and each request is still sorted against its own filename by `sortSubsByFilename` afterwards, so your line in the issue holds: *the same subtitles array just sorted differently*.

Deliberately **not** keyed on the imdb id. It is spent resolving the Ktuvit ID in `extractTitleInfo` and never read again, so keying on it would mean trusting that the mapping never changes. Keying on the Ktuvit ID also means a re-indexed title refetches instead of serving a stale list until the entry expires. Both behaviours have a test.

## Policies

| | |
| --- | --- |
| List found | 1 hour |
| List empty | 5 minutes, since it usually means the subs are not up yet rather than that this title will never have any |
| Fetch failed | **never cached** |
| Full | LRU eviction at 500 titles, about 5MB |
| In flight | the pending promise is cached, so simultaneous requests share one fetch |

The failure rule is the one I would highlight: caching a failure would turn a single bad response from Ktuvit into an empty subtitles list for every viewer until it expired, which is the same trap bc7ea51 fixed for SRT files.

Lists are handed out as copies, so a caller sorting in place cannot reorder what the next request reads.

All three are configurable: `SUBS_CACHE_MAX_ENTRIES`, `SUBS_CACHE_FOUND_TTL_MS`, `SUBS_CACHE_EMPTY_TTL_MS`.

## The change to subs.js is three lines

```js
const ktuvitFetchedSubs = await getOrFetch(req.title, () =>
  fetchSubsFromKtuvit(req.title)
);
```

The existing try/catch is untouched and still does its job: `getOrFetch` rethrows, so the catch logs and falls back to an empty list, and because the cache dropped the entry that empty list is not remembered.

## Tests

`npm test` goes from 9 to 36 passing.

**Correction:** as first pushed this said 36 while an actual run reported 34 passing, 2 failing — @maormagori caught it. Both failures were in the expiry suite and were harness bugs, not cache bugs; fixed in 825304e, and the 36 now holds. Detail in [the thread](https://github.com/maormagori/ktuvit-stremio/pull/80#issuecomment-5385068563), but the short version is that `lru-cache` resolves its clock at require time and `sinon` replaces the global `performance` object rather than patching it, so the fake clock never reached the cache.

**`test/unit/common/subsCache.spec.js`** — 24 tests, all driven through `getOrFetch` and asserting how many times Ktuvit would have been called, since that count is the point of the whole feature. Seven cases that must share one entry (including the two URLs from the issue, and five releases of one episode costing one call), seven that must not (adjacent episodes, adjacent seasons, different series, a re-indexed Ktuvit ID), then single flight, failure, copy on read, eviction, and both ttls via `sinon`'s fake timers.

**`test/unit/routes/subs.spec.js`** — 3 tests on the wiring: two viewers on different releases cost one call, a cached list still reaches the request, and a failed fetch neither sticks nor breaks the empty-list fallback.

The fixtures are shaped like the `req.title` that `extractTitleInfo` actually builds, verified against it: `season` and `episode` are strings for a series and present but undefined for a movie, and `ktuvitID` always comes along.

Every test was mutation checked rather than assumed to work. Keying on the imdb id instead fails 3, dropping the type fails 1, including the filename fails 8, caching failures fails 2, giving empty lists the long ttl fails 2, removing single flight fails 2, and bypassing the cache fails 20. Two tests did **not** fail when they should have and were fixed: the copy-on-read test was comparing against an array the test itself had mutated, and nothing pinned the type until a case was added where only the type differs.

The expiry suite was a third case of this, missed until @maormagori's review. Four of its tests assert that a list is still served just before its ttl, which holds trivially while nothing expires at all — so they were green for the wrong reason rather than genuinely covering the ttl. Re-checked after 825304e: putting empty lists on the long ttl fails 1, found lists on the short ttl fails 2, and disabling expiry outright fails 2.

## Notes

- `lru-cache` is pinned to `^10.4.3`. The current 11.x declares engines `20 || >=22` and fails to load below that with a `tracingChannel` error; 10.4.3 declares no engine restriction.
- The cache is per process, so hit rates are per dyno and a restart empties it. Fine for this workload, and not worth a shared store.
- I did not add a `Cache-Control` header to the subtitles response. It would let the edge hold empty results for a shorter time than found ones, but it is a separate concern from this issue and easy to add later if you want it.
- Depends on nothing, but pairs with #78: the cache logs hit and miss at debug level, which only becomes visible once `LOG_LEVEL` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

